### PR TITLE
Increased the `TryAtSoftware.Randomizer` package version to v2.0.1

### DIFF
--- a/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
+++ b/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 		
         <PackageId>TryAtSoftware.Randomizer</PackageId>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/Randomizer</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR will introduce a new major release for the `TryAtSoftware.Randomizer` package that should fix some critical usability issues introduce by the previous one. Because the 2.0.0 release will be deprecated, we avoided increasing the major version once again.