### PR TITLE
Methods for randomizing numbers of type `int`, `uint`, `long`, `ulong`, `float`, `double` and `byte[]`

### DIFF
--- a/src/TryAtSoftware.Randomizer.Core/GeneralInstanceBuilder.cs
+++ b/src/TryAtSoftware.Randomizer.Core/GeneralInstanceBuilder.cs
@@ -31,7 +31,7 @@ public class GeneralInstanceBuilder<TEntity> : IInstanceBuilder<TEntity>
     }
 
     private static bool CanConstructInstance(IInstanceBuildingArguments arguments, ParameterInfo[] constructorParameters)
-        => constructorParameters.All(x => x.HasDefaultValue || arguments.ContainsParameter(x.Name));
+        => Array.TrueForAll(constructorParameters, x => x.HasDefaultValue || arguments.ContainsParameter(x.Name));
 
     private static (TEntity Instance, HashSet<string> UsedParameterNames) ConstructNewInstance(IInstanceBuildingArguments arguments, ParameterInfo[] parameters, Func<object?[], TEntity> objectInitializer)
     {

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 
 public static class RandomizationHelper
@@ -11,28 +10,47 @@ public static class RandomizationHelper
     public const string LOWER_CASE_LETTERS = "abcdefghijklmnopqrstuvwxyz";
     public const string UPPER_CASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string DIGITS = "0123456789";
+    public const string ALL_CHARACTERS = $"{LOWER_CASE_LETTERS}{UPPER_CASE_LETTERS}{DIGITS}";
+
+    private static Random _random = new ();
+
+    public static int RandomInteger() => RandomInteger(0, int.MaxValue);
 
     public static int RandomInteger(int inclusiveBottomBound, int exclusiveUpperBound)
     {
         if (exclusiveUpperBound <= inclusiveBottomBound) throw new InvalidOperationException("The maximum value for the random number that should be generated cannot be lower than or equal to the minimum.");
-        if (exclusiveUpperBound == inclusiveBottomBound + 1) return inclusiveBottomBound;
 
-        using var rng = new RNGCryptoServiceProvider();
-        var data = new byte[4];
-        rng.GetBytes(data);
+        var range = (uint)(exclusiveUpperBound - inclusiveBottomBound);
+        var limit = uint.MaxValue - uint.MaxValue % range;
 
-        var generatedValue = BitConverter.ToInt32(data, startIndex: 0);
+        uint result;
+        do
+        {
+            result = RandomUInt32();
+        } while (result > limit);
 
-        var difference = exclusiveUpperBound - inclusiveBottomBound;
-        var differenceOffset = Math.Abs(generatedValue) % difference;
-        return inclusiveBottomBound + differenceOffset;
+        return inclusiveBottomBound + (int)(result % range);
     }
 
-    public static string GetRandomString()
+    public static long RandomLongInteger() => RandomLongInteger(0, long.MaxValue);
+
+    public static long RandomLongInteger(long inclusiveBottomBound, long exclusiveUpperBound)
     {
-        var charactersMask = $"{LOWER_CASE_LETTERS}{UPPER_CASE_LETTERS}{DIGITS}";
-        return GetRandomString(RandomInteger(30, 80), charactersMask);
+        if (exclusiveUpperBound <= inclusiveBottomBound) throw new InvalidOperationException("The maximum value for the random number that should be generated cannot be lower than or equal to the minimum.");
+
+        var range = (ulong)(exclusiveUpperBound - inclusiveBottomBound);
+        var limit = ulong.MaxValue - ulong.MaxValue % range;
+
+        ulong result;
+        do
+        {
+            result = RandomUInt64();
+        } while (result > limit);
+
+        return inclusiveBottomBound + (long)(result % range);
     }
+
+    public static string GetRandomString() => GetRandomString(RandomInteger(30, 80), ALL_CHARACTERS);
 
     public static string GetRandomString(int length, string charactersMask)
     {
@@ -64,12 +82,22 @@ public static class RandomizationHelper
 
     public static DateTimeOffset GetRandomDateTimeOffset(bool historical = false)
     {
-        var randomRepetitionsCount = RandomInteger(3, 6);
-        long ticks = 1;
-        for (var i = 0; i < randomRepetitionsCount; i++)
-            ticks *= RandomInteger(10, 1000);
-
+        var ticks = RandomLongInteger(0, long.MaxValue);
         var randTimeSpan = new TimeSpan(ticks);
         return historical ? DateTimeOffset.Now.Add(-randTimeSpan) : DateTimeOffset.Now.Add(randTimeSpan);
+    }
+
+    private static uint RandomUInt32()
+    {
+        var buffer = new byte[4];
+        _random.NextBytes(buffer);
+        return BitConverter.ToUInt32(buffer);
+    }
+
+    private static ulong RandomUInt64()
+    {
+        var buffer = new byte[8];
+        _random.NextBytes(buffer);
+        return BitConverter.ToUInt64(buffer);
     }
 }

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 
 public static class RandomizationHelper
@@ -14,8 +15,6 @@ public static class RandomizationHelper
     public const string UPPER_CASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string DIGITS = "0123456789";
     public const string ALL_CHARACTERS = $"{LOWER_CASE_LETTERS}{UPPER_CASE_LETTERS}{DIGITS}";
-
-    private static Random _random = new ();
 
     public static int RandomInteger() => RandomInteger(int.MinValue, int.MaxValue, upperBoundIsExclusive: false);
 
@@ -85,6 +84,13 @@ public static class RandomizationHelper
     
     public static float RandomFloat() => (RandomUInt64() >> 40) * RANDOM_SINGLE_CONSTANT;
 
+    public static byte[] RandomBytes(int length)
+    {
+        var result = new byte[length];
+        RandomNumberGenerator.Fill(result);
+        return result;
+    }
+
     public static string GetRandomString() => GetRandomString(RandomInteger(30, 80), ALL_CHARACTERS);
 
     public static string GetRandomString(int length, string charactersMask)
@@ -122,17 +128,7 @@ public static class RandomizationHelper
         return historical ? DateTimeOffset.Now.Add(-randTimeSpan) : DateTimeOffset.Now.Add(randTimeSpan);
     }
 
-    private static uint RandomUInt32()
-    {
-        var buffer = new byte[4];
-        _random.NextBytes(buffer);
-        return BitConverter.ToUInt32(buffer);
-    }
+    private static uint RandomUInt32() => BitConverter.ToUInt32(RandomBytes(4));
 
-    private static ulong RandomUInt64()
-    {
-        var buffer = new byte[8];
-        _random.NextBytes(buffer);
-        return BitConverter.ToUInt64(buffer);
-    }
+    private static ulong RandomUInt64() => BitConverter.ToUInt64(RandomBytes(8));
 }

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 public static class RandomizationHelper
 {
+    private const double RANDOM_DOUBLE_CONSTANT = 1.0 / (1UL << 53);
     public const string LOWER_CASE_LETTERS = "abcdefghijklmnopqrstuvwxyz";
     public const string UPPER_CASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string DIGITS = "0123456789";
@@ -14,13 +15,31 @@ public static class RandomizationHelper
 
     private static Random _random = new ();
 
-    public static int RandomInteger() => RandomInteger(0, int.MaxValue);
+    public static int RandomInteger() => RandomInteger(int.MinValue, int.MaxValue, upperBoundIsExclusive: false);
 
-    public static int RandomInteger(int inclusiveBottomBound, int exclusiveUpperBound)
+    public static int RandomInteger(int inclusiveLowerBound, int exclusiveUpperBound) => RandomInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
+
+    public static int RandomInteger(int inclusiveLowerBound, int upperBound, bool upperBoundIsExclusive)
     {
-        if (exclusiveUpperBound <= inclusiveBottomBound) throw new InvalidOperationException("The maximum value for the random number that should be generated cannot be lower than or equal to the minimum.");
+        var randomAdditive = RandomUnsignedInteger(0U, (uint)(upperBound - inclusiveLowerBound), upperBoundIsExclusive);
+        return inclusiveLowerBound + (int)randomAdditive;
+    }
 
-        var range = (uint)(exclusiveUpperBound - inclusiveBottomBound);
+    public static uint RandomUnsignedInteger() => RandomUnsignedInteger(uint.MinValue, uint.MaxValue, upperBoundIsExclusive: false);
+
+    public static uint RandomUnsignedInteger(uint inclusiveLowerBound, uint exclusiveUpperBound) => RandomUnsignedInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
+
+    public static uint RandomUnsignedInteger(uint inclusiveLowerBound, uint upperBound, bool upperBoundIsExclusive)
+    {
+        if (upperBound < inclusiveLowerBound || (upperBoundIsExclusive && upperBound == inclusiveLowerBound)) throw new InvalidOperationException("The upper bound for the random number that should be generated cannot be lower than or equal to the lower bound.");
+        
+        var range = upperBound - inclusiveLowerBound;
+        if (!upperBoundIsExclusive)
+        {
+            if (range == uint.MaxValue) return RandomUInt32();
+            range++;
+        }
+
         var limit = uint.MaxValue - uint.MaxValue % range;
 
         uint result;
@@ -29,16 +48,34 @@ public static class RandomizationHelper
             result = RandomUInt32();
         } while (result > limit);
 
-        return inclusiveBottomBound + (int)(result % range);
+        return inclusiveLowerBound + result % range;
     }
 
-    public static long RandomLongInteger() => RandomLongInteger(0, long.MaxValue);
+    public static long RandomLongInteger() => RandomLongInteger(long.MinValue, long.MaxValue, upperBoundIsExclusive: false);
 
-    public static long RandomLongInteger(long inclusiveBottomBound, long exclusiveUpperBound)
+    public static long RandomLongInteger(long inclusiveLowerBound, long exclusiveUpperBound) => RandomLongInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
+
+    public static long RandomLongInteger(long inclusiveLowerBound, long upperBound, bool upperBoundIsExclusive)
     {
-        if (exclusiveUpperBound <= inclusiveBottomBound) throw new InvalidOperationException("The maximum value for the random number that should be generated cannot be lower than or equal to the minimum.");
+        var randomAdditive = RandomUnsignedLongInteger(0U, (ulong)(upperBound - inclusiveLowerBound), upperBoundIsExclusive);
+        return inclusiveLowerBound + (long)randomAdditive;
+    }
 
-        var range = (ulong)(exclusiveUpperBound - inclusiveBottomBound);
+    public static ulong RandomUnsignedLongInteger() => RandomUnsignedLongInteger(ulong.MinValue, ulong.MaxValue, upperBoundIsExclusive: false);
+
+    public static ulong RandomUnsignedLongInteger(ulong inclusiveLowerBound, ulong exclusiveUpperBound) => RandomUnsignedLongInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
+
+    public static ulong RandomUnsignedLongInteger(ulong inclusiveLowerBound, ulong upperBound, bool upperBoundIsExclusive)
+    {
+        if (upperBound < inclusiveLowerBound || (upperBoundIsExclusive && upperBound == inclusiveLowerBound)) throw new InvalidOperationException("The upper bound for the random number that should be generated cannot be lower than or equal to the lower bound.");
+        
+        var range = upperBound - inclusiveLowerBound;
+        if (!upperBoundIsExclusive)
+        {
+            if (range == ulong.MaxValue) return RandomUInt64();
+            range++;
+        }
+
         var limit = ulong.MaxValue - ulong.MaxValue % range;
 
         ulong result;
@@ -47,8 +84,10 @@ public static class RandomizationHelper
             result = RandomUInt64();
         } while (result > limit);
 
-        return inclusiveBottomBound + (long)(result % range);
+        return inclusiveLowerBound + result % range;
     }
+
+    public static double RandomDouble() => (RandomUInt64() >> 11) * RANDOM_DOUBLE_CONSTANT;
 
     public static string GetRandomString() => GetRandomString(RandomInteger(30, 80), ALL_CHARACTERS);
 

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -8,6 +8,8 @@ using System.Text;
 public static class RandomizationHelper
 {
     private const double RANDOM_DOUBLE_CONSTANT = 1.0 / (1UL << 53);
+    private const float RANDOM_SINGLE_CONSTANT = 1.0f / (1UL << 24);
+
     public const string LOWER_CASE_LETTERS = "abcdefghijklmnopqrstuvwxyz";
     public const string UPPER_CASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     public const string DIGITS = "0123456789";
@@ -80,6 +82,8 @@ public static class RandomizationHelper
     }
 
     public static double RandomDouble() => (RandomUInt64() >> 11) * RANDOM_DOUBLE_CONSTANT;
+    
+    public static float RandomFloat() => (RandomUInt64() >> 40) * RANDOM_SINGLE_CONSTANT;
 
     public static string GetRandomString() => GetRandomString(RandomInteger(30, 80), ALL_CHARACTERS);
 

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -2,18 +2,35 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
+/// <summary>
+/// A static class containing helper methods for randomizing primitives.
+/// </summary>
 public static class RandomizationHelper
 {
     private const double RANDOM_DOUBLE_CONSTANT = 1.0 / (1UL << 53);
     private const float RANDOM_SINGLE_CONSTANT = 1.0f / (1UL << 24);
 
+    /// <summary>
+    /// All letters from the Latin alphabet in lower case.
+    /// </summary>
     public const string LOWER_CASE_LETTERS = "abcdefghijklmnopqrstuvwxyz";
+    
+    /// <summary>
+    /// All letters from the Latin alphabet in upper case.
+    /// </summary>
     public const string UPPER_CASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    
+    /// <summary>
+    /// All digits.
+    /// </summary>
     public const string DIGITS = "0123456789";
+    
+    /// <summary>
+    /// All letters from the Latin alphabet in lower and upper case and all digits.
+    /// </summary>
     public const string ALL_CHARACTERS = $"{LOWER_CASE_LETTERS}{UPPER_CASE_LETTERS}{DIGITS}";
 
     /// <summary>
@@ -153,33 +170,59 @@ public static class RandomizationHelper
         return result;
     }
 
+    /// <summary>
+    /// Generates a random string with random length using the <see cref="ALL_CHARACTERS"/> mask.
+    /// </summary>
     public static string GetRandomString() => GetRandomString(RandomInteger(30, 80), ALL_CHARACTERS);
 
+    /// <summary>
+    /// Generates a random string by a given length and characters mask.
+    /// </summary>
+    /// <param name="length">The length of the string that should be generated.</param>
+    /// <param name="charactersMask">All characters that can be used when generating the string.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown, if the provided <paramref name="length"/> is lower than or equal to zero.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="charactersMask"/> is null or empty.</exception>
     public static string GetRandomString(int length, string charactersMask)
     {
         if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
         if (string.IsNullOrEmpty(charactersMask)) throw new ArgumentNullException(nameof(charactersMask));
 
         // Returns a random string with given length, it uses the characters above.
-        return GetRandomStringCombination(length, charactersMask.ToList().AsReadOnly());
+        return GetRandomString(length, charactersMask.ToCharArray());
     }
 
-    public static string GetRandomStringCombination(int length, IReadOnlyList<char> possibleChars)
+    /// <summary>
+    /// Generates a random string by a given length and characters mask.
+    /// </summary>
+    /// <param name="length">The length of the string that should be generated.</param>
+    /// <param name="charactersMask">All characters that can be used when generating the string.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown, if the provided <paramref name="length"/> is lower than or equal to zero.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="charactersMask"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if the provided <paramref name="charactersMask"/> is empty.</exception>
+    public static string GetRandomString(int length, IReadOnlyList<char> charactersMask)
     {
         if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
-        if (possibleChars is null) throw new ArgumentNullException(nameof(possibleChars));
-        if (possibleChars.Count == 0) throw new ArgumentException("The characters mask must include at least one character.", nameof(possibleChars));
+        if (charactersMask is null) throw new ArgumentNullException(nameof(charactersMask));
+        if (charactersMask.Count == 0) throw new ArgumentException("The characters mask must include at least one character.", nameof(charactersMask));
 
         var sb = new StringBuilder(length);
 
         for (var i = 0; i < length; i++)
-            sb.Append(possibleChars[RandomInteger(0, possibleChars.Count)]);
+            sb.Append(charactersMask[RandomInteger(0, charactersMask.Count)]);
 
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Generates a random boolean.
+    /// </summary>
+    /// <param name="percents">The likelihood (out of 100) for this method to return <c>true</c>.</param>
     public static bool RandomProbability(int percents = 50) => RandomInteger(0, 100) < percents;
 
+    /// <summary>
+    /// Generates a random <see cref="DateTimeOffset"/> value.
+    /// </summary>
+    /// <param name="historical">Value indicating whether the generated value should be in the past (if <c>true</c>) or in the future (if <c>false</c>).</param>
     public static DateTimeOffset GetRandomDateTimeOffset(bool historical = false)
     {
         var ticks = RandomLongInteger(0, 100000);

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -16,28 +16,100 @@ public static class RandomizationHelper
     public const string DIGITS = "0123456789";
     public const string ALL_CHARACTERS = $"{LOWER_CASE_LETTERS}{UPPER_CASE_LETTERS}{DIGITS}";
 
+    /// <summary>
+    /// Generates a random 32-bit integer in the range [Int32.MinValue, Int32.MaxValue].
+    /// </summary>
     public static int RandomInteger() => RandomInteger(int.MinValue, int.MaxValue, upperBoundIsExclusive: false);
 
+    /// <summary>
+    /// Generates a random 32-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="exclusiveUpperBound"/>).
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="exclusiveUpperBound">One more than the greatest value that can be generated. This parameter is exclusive.</param>
     public static int RandomInteger(int inclusiveLowerBound, int exclusiveUpperBound) => RandomInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
+    /// <summary>
+    /// Generates a random 32-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>) if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// Generates a random 32-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>] if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="upperBound">
+    /// One more than the greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// The greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// Whether this parameter is inclusive or exclusive, depends on <paramref name="upperBoundIsExclusive"/>.</param>
+    /// <param name="upperBoundIsExclusive">A value indicating whether the <paramref name="upperBound"/> is an inclusive or an exclusive parameter.</param>
     public static int RandomInteger(int inclusiveLowerBound, int upperBound, bool upperBoundIsExclusive) => int.MinValue + (int)RandomUnsignedInteger((uint)(inclusiveLowerBound - int.MinValue), (uint)(upperBound - int.MinValue), upperBoundIsExclusive);
 
+    /// <summary>
+    /// Generates a random 32-bit unsigned integer in the range [UInt32.MinValue, UInt32.MaxValue].
+    /// </summary>
     public static uint RandomUnsignedInteger() => RandomUnsignedInteger(uint.MinValue, uint.MaxValue, upperBoundIsExclusive: false);
 
+    /// <summary>
+    /// Generates a random 32-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="exclusiveUpperBound"/>).
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="exclusiveUpperBound">One more than the greatest value that can be generated. This parameter is exclusive.</param>
     public static uint RandomUnsignedInteger(uint inclusiveLowerBound, uint exclusiveUpperBound) => RandomUnsignedInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
+    /// <summary>
+    /// Generates a random 32-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>) if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// Generates a random 32-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>] if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="upperBound">
+    /// One more than the greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// The greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// Whether this parameter is inclusive or exclusive, depends on <paramref name="upperBoundIsExclusive"/>.</param>
+    /// <param name="upperBoundIsExclusive">A value indicating whether the <paramref name="upperBound"/> is an inclusive or an exclusive parameter.</param>
     public static uint RandomUnsignedInteger(uint inclusiveLowerBound, uint upperBound, bool upperBoundIsExclusive) => (uint) RandomUnsignedLongInteger(inclusiveLowerBound, upperBound, upperBoundIsExclusive);
 
+    /// <summary>
+    /// Generates a random 64-bit integer in the range [Int64.MinValue, Int64.MaxValue].
+    /// </summary>
     public static long RandomLongInteger() => RandomLongInteger(long.MinValue, long.MaxValue, upperBoundIsExclusive: false);
 
+    /// <summary>
+    /// Generates a random 64-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="exclusiveUpperBound"/>).
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="exclusiveUpperBound">One more than the greatest value that can be generated. This parameter is exclusive.</param>
     public static long RandomLongInteger(long inclusiveLowerBound, long exclusiveUpperBound) => RandomLongInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
+    /// <summary>
+    /// Generates a random 64-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>) if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// Generates a random 64-bit integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>] if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="upperBound">
+    /// One more than the greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// The greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// Whether this parameter is inclusive or exclusive, depends on <paramref name="upperBoundIsExclusive"/>.</param>
+    /// <param name="upperBoundIsExclusive">A value indicating whether the <paramref name="upperBound"/> is an inclusive or an exclusive parameter.</param>
     public static long RandomLongInteger(long inclusiveLowerBound, long upperBound, bool upperBoundIsExclusive) => long.MinValue + (long)RandomUnsignedLongInteger((ulong)(inclusiveLowerBound - long.MinValue), (ulong)(upperBound - long.MinValue), upperBoundIsExclusive);
 
+    /// <summary>
+    /// Generates a random 64-bit unsigned integer in the range [Int64.MinValue, Int64.MaxValue].
+    /// </summary>
     public static ulong RandomUnsignedLongInteger() => RandomUnsignedLongInteger(ulong.MinValue, ulong.MaxValue, upperBoundIsExclusive: false);
 
+    /// <summary>
+    /// Generates a random 64-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="exclusiveUpperBound"/>).
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="exclusiveUpperBound">One more than the greatest value that can be generated. This parameter is exclusive.</param>
     public static ulong RandomUnsignedLongInteger(ulong inclusiveLowerBound, ulong exclusiveUpperBound) => RandomUnsignedLongInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
+    /// <summary>
+    /// Generates a random 64-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>) if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// Generates a random 64-bit unsigned integer in the range [<paramref name="inclusiveLowerBound"/>, <paramref name="upperBound"/>] if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// </summary>
+    /// <param name="inclusiveLowerBound">The lowest value that can be generated. This parameter is inclusive.</param>
+    /// <param name="upperBound">
+    /// One more than the greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>true</c>.
+    /// The greatest value that can be generated if <paramref name="upperBoundIsExclusive"/> is <c>false</c>.
+    /// Whether this parameter is inclusive or exclusive, depends on <paramref name="upperBoundIsExclusive"/>.</param>
+    /// <param name="upperBoundIsExclusive">A value indicating whether the <paramref name="upperBound"/> is an inclusive or an exclusive parameter.</param>
     public static ulong RandomUnsignedLongInteger(ulong inclusiveLowerBound, ulong upperBound, bool upperBoundIsExclusive)
     {
         if (upperBound < inclusiveLowerBound || (upperBoundIsExclusive && upperBound == inclusiveLowerBound)) throw new InvalidOperationException(GetInvalidRangeExceptionMessage(upperBoundIsExclusive));
@@ -60,10 +132,20 @@ public static class RandomizationHelper
         return inclusiveLowerBound + result % range;
     }
 
+    /// <summary>
+    /// Generates a random floating-point number of type <see cref="double"/> in the range [0, 1).
+    /// </summary>
     public static double RandomDouble() => (RandomUInt64() >> 11) * RANDOM_DOUBLE_CONSTANT;
     
+    /// <summary>
+    /// Generates a random floating-point number of type <see cref="float"/> in the range [0, 1).
+    /// </summary>
     public static float RandomFloat() => (RandomUInt64() >> 40) * RANDOM_SINGLE_CONSTANT;
 
+    /// <summary>
+    /// Generates an array filled with random bytes.
+    /// </summary>
+    /// <param name="length">The length of the generated array of bytes.</param>
     public static byte[] RandomBytes(int length)
     {
         var result = new byte[length];

--- a/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
+++ b/src/TryAtSoftware.Randomizer.Core/Helpers/RandomizationHelper.cs
@@ -19,11 +19,7 @@ public static class RandomizationHelper
 
     public static int RandomInteger(int inclusiveLowerBound, int exclusiveUpperBound) => RandomInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
-    public static int RandomInteger(int inclusiveLowerBound, int upperBound, bool upperBoundIsExclusive)
-    {
-        var randomAdditive = RandomUnsignedInteger(0U, (uint)(upperBound - inclusiveLowerBound), upperBoundIsExclusive);
-        return inclusiveLowerBound + (int)randomAdditive;
-    }
+    public static int RandomInteger(int inclusiveLowerBound, int upperBound, bool upperBoundIsExclusive) => int.MinValue + (int)RandomUnsignedInteger((uint)(inclusiveLowerBound - int.MinValue), (uint)(upperBound - int.MinValue), upperBoundIsExclusive);
 
     public static uint RandomUnsignedInteger() => RandomUnsignedInteger(uint.MinValue, uint.MaxValue, upperBoundIsExclusive: false);
 
@@ -55,11 +51,7 @@ public static class RandomizationHelper
 
     public static long RandomLongInteger(long inclusiveLowerBound, long exclusiveUpperBound) => RandomLongInteger(inclusiveLowerBound, exclusiveUpperBound, upperBoundIsExclusive: true);
 
-    public static long RandomLongInteger(long inclusiveLowerBound, long upperBound, bool upperBoundIsExclusive)
-    {
-        var randomAdditive = RandomUnsignedLongInteger(0U, (ulong)(upperBound - inclusiveLowerBound), upperBoundIsExclusive);
-        return inclusiveLowerBound + (long)randomAdditive;
-    }
+    public static long RandomLongInteger(long inclusiveLowerBound, long upperBound, bool upperBoundIsExclusive) => long.MinValue + (long)RandomUnsignedLongInteger((ulong)(inclusiveLowerBound - long.MinValue), (ulong)(upperBound - long.MinValue), upperBoundIsExclusive);
 
     public static ulong RandomUnsignedLongInteger() => RandomUnsignedLongInteger(ulong.MinValue, ulong.MaxValue, upperBoundIsExclusive: false);
 
@@ -121,7 +113,7 @@ public static class RandomizationHelper
 
     public static DateTimeOffset GetRandomDateTimeOffset(bool historical = false)
     {
-        var ticks = RandomLongInteger(0, long.MaxValue);
+        var ticks = RandomLongInteger(0, 100000);
         var randTimeSpan = new TimeSpan(ticks);
         return historical ? DateTimeOffset.Now.Add(-randTimeSpan) : DateTimeOffset.Now.Add(randTimeSpan);
     }

--- a/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
+++ b/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.3.0.71466">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -1,6 +1,7 @@
 namespace TryAtSoftware.Randomizer.Core.Tests.PrimitiveRandomization;
 
 using System;
+using System.Collections.Generic;
 using TryAtSoftware.Randomizer.Core.Helpers;
 using Xunit;
 
@@ -12,31 +13,99 @@ public class RandomizationHelperTests
         Assert.Throws<ArgumentOutOfRangeException>(() => RandomizationHelper.GetRandomString(-1, "mask"));
     }
 
-    [Theory]
-    [MemberData(nameof(TestsHelper.GetInvalidStringParameters), MemberType = typeof(TestsHelper))]
-    public void GetRandomStringShouldValidateMask(string mask)
+    [Fact]
+    public void GetRandomStringShouldValidateMask()
     {
-        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, mask));
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, null!));
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, string.Empty));
     }
 
     [Fact]
-    public void RandomIntegerShouldNeverExceedBoundaries()
+    public void RandomIntegerShouldBeGeneratedCorrectly()
     {
         const int iterations = 10000;
         for (var i = 1; i <= iterations; i++)
         {
-            var randomInteger = RandomizationHelper.RandomInteger(0, i);
+            var randomNumber = RandomizationHelper.RandomInteger(0, i);
 
-            Assert.True(randomInteger >= 0);
-            Assert.True(randomInteger < i);
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber < i);
         }
 
         for (var i = 1; i <= iterations; i++)
         {
-            var randomInteger = RandomizationHelper.RandomInteger(0, i, upperBoundIsExclusive: false);
+            var randomNumber = RandomizationHelper.RandomInteger(0, i, upperBoundIsExclusive: false);
 
-            Assert.True(randomInteger >= 0);
-            Assert.True(randomInteger <= i);
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber <= i);
+        }
+
+        var seen = new HashSet<int>();
+        for (var i = 0; i < iterations; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomInteger();
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomUnsignedIntegerShouldBeGeneratedCorrectly()
+    {
+        const uint iterations = 10000;
+        for (var i = 1U; i <= iterations; i++)
+        {
+            uint inclusiveLowerBound = 1000U, exclusiveUpperBound = 1000U + i;
+            var randomNumber = RandomizationHelper.RandomUnsignedInteger(inclusiveLowerBound, exclusiveUpperBound);
+
+            Assert.True(randomNumber >= inclusiveLowerBound);
+            Assert.True(randomNumber < exclusiveUpperBound);
+        }
+
+        for (var i = 1U; i <= iterations; i++)
+        {
+            uint inclusiveLowerBound = 1000U, inclusiveUpperBound = 1000U + i;
+            var randomNumber = RandomizationHelper.RandomUnsignedInteger(inclusiveLowerBound, inclusiveUpperBound, upperBoundIsExclusive: false);
+
+            Assert.True(randomNumber >= inclusiveLowerBound);
+            Assert.True(randomNumber <= inclusiveUpperBound);
+        }
+
+        var seen = new HashSet<uint>();
+        for (var i = 0; i < iterations; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomUnsignedInteger();
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomLongIntegerShouldBeGeneratedCorrectly()
+    {
+        const int iterations = 10000;
+        for (var i = 1; i <= iterations; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomLongInteger(0, i);
+
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber < i);
+        }
+
+        for (var i = 1; i <= iterations; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomLongInteger(0, i, upperBoundIsExclusive: false);
+
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber <= i);
+        }
+
+        var seen = new HashSet<long>();
+        for (var i = 0; i < iterations; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomLongInteger();
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
         }
     }
 

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -32,7 +32,7 @@ public class RandomizationHelperTests
     public void GetRandomStringCombinationShouldValidateMask()
     {
         Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomStringCombination(5, null!));
-        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomStringCombination(5, Array.Empty<char>()));
+        Assert.Throws<ArgumentException>(() => RandomizationHelper.GetRandomStringCombination(5, Array.Empty<char>()));
     }
 
     [Fact]
@@ -195,7 +195,7 @@ public class RandomizationHelperTests
             Assert.DoesNotContain(randomPastDateTime, seen);
             seen.Add(randomPastDateTime);
 
-            var randomFutureDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: true);
+            var randomFutureDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: false);
             Assert.True(randomFutureDateTime > DateTimeOffset.Now);
 
             Assert.DoesNotContain(randomFutureDateTime, seen);

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 public class RandomizationHelperTests
 {
     private const int ITERATIONS = 500;
-    
+
     [Fact]
     public void GetRandomStringShouldValidateLength()
     {
@@ -20,6 +20,19 @@ public class RandomizationHelperTests
     {
         Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, null!));
         Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, string.Empty));
+    }
+
+    [Fact]
+    public void GetRandomStringCombinationShouldValidateLength()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => RandomizationHelper.GetRandomStringCombination(-1, new[] { 'a' }));
+    }
+
+    [Fact]
+    public void GetRandomStringCombinationShouldValidateMask()
+    {
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomStringCombination(5, null!));
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomStringCombination(5, Array.Empty<char>()));
     }
 
     [Fact]
@@ -139,13 +152,13 @@ public class RandomizationHelperTests
     }
 
     [Fact]
-    public void RandomDoubleShouldWorkCorrectly()
+    public void RandomDoubleShouldBeGeneratedCorrectly()
     {
         var seen = new HashSet<double>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomDouble();
-            
+
             Assert.True(randomNumber >= 0);
             Assert.True(randomNumber < 1);
 
@@ -155,18 +168,38 @@ public class RandomizationHelperTests
     }
 
     [Fact]
-    public void RandomFloatShouldWorkCorrectly()
+    public void RandomFloatShouldBeGeneratedCorrectly()
     {
         var seen = new HashSet<float>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomFloat();
-            
+
             Assert.True(randomNumber >= 0);
             Assert.True(randomNumber < 1);
 
             Assert.DoesNotContain(randomNumber, seen);
             seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomDateTimeOffsetShouldBeGeneratedCorrectly()
+    {
+        var seen = new HashSet<DateTimeOffset>();
+        for (var i = 0; i < ITERATIONS; i++)
+        {
+            var randomPastDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: true);
+            Assert.True(randomPastDateTime < DateTimeOffset.Now);
+
+            Assert.DoesNotContain(randomPastDateTime, seen);
+            seen.Add(randomPastDateTime);
+
+            var randomFutureDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: true);
+            Assert.True(randomFutureDateTime > DateTimeOffset.Now);
+
+            Assert.DoesNotContain(randomFutureDateTime, seen);
+            seen.Add(randomPastDateTime);
         }
     }
 

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -54,12 +54,15 @@ public class RandomizationHelperTests
             Assert.True(randomNumber <= i);
         }
 
-        var seen = new HashSet<int>();
+        var seen = new Dictionary<int, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomInteger();
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
@@ -84,12 +87,15 @@ public class RandomizationHelperTests
             Assert.True(randomNumber <= inclusiveUpperBound);
         }
 
-        var seen = new HashSet<uint>();
+        var seen = new Dictionary<uint, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomUnsignedInteger();
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
@@ -112,12 +118,15 @@ public class RandomizationHelperTests
             Assert.True(randomNumber <= i);
         }
 
-        var seen = new HashSet<long>();
+        var seen = new Dictionary<long, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomLongInteger();
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
@@ -142,64 +151,75 @@ public class RandomizationHelperTests
             Assert.True(randomNumber <= inclusiveUpperBound);
         }
 
-        var seen = new HashSet<ulong>();
+        var seen = new Dictionary<ulong, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomUnsignedLongInteger();
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
     [Fact]
     public void RandomDoubleShouldBeGeneratedCorrectly()
     {
-        var seen = new HashSet<double>();
+        var seen = new Dictionary<double, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomDouble();
 
             Assert.True(randomNumber >= 0);
             Assert.True(randomNumber < 1);
-
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
     [Fact]
     public void RandomFloatShouldBeGeneratedCorrectly()
     {
-        var seen = new HashSet<float>();
+        var seen = new Dictionary<float, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomFloat();
 
             Assert.True(randomNumber >= 0);
             Assert.True(randomNumber < 1);
-
-            Assert.DoesNotContain(randomNumber, seen);
-            seen.Add(randomNumber);
+            
+            seen.TryAdd(randomNumber, 0);
+            seen[randomNumber]++;
+            
+            Assert.True(seen[randomNumber] <= 2);
         }
     }
 
     [Fact]
     public void RandomDateTimeOffsetShouldBeGeneratedCorrectly()
     {
-        var seen = new HashSet<DateTimeOffset>();
+        var seen = new Dictionary<DateTimeOffset, int>();
         for (var i = 0; i < ITERATIONS; i++)
         {
             var randomPastDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: true);
             Assert.True(randomPastDateTime < DateTimeOffset.Now);
 
-            Assert.DoesNotContain(randomPastDateTime, seen);
-            seen.Add(randomPastDateTime);
+            seen.TryAdd(randomPastDateTime, 0);
+            seen[randomPastDateTime]++;
+            
+            Assert.True(seen[randomPastDateTime] <= 2);
 
             var randomFutureDateTime = RandomizationHelper.GetRandomDateTimeOffset(historical: false);
             Assert.True(randomFutureDateTime > DateTimeOffset.Now);
 
-            Assert.DoesNotContain(randomFutureDateTime, seen);
-            seen.Add(randomPastDateTime);
+            seen.TryAdd(randomFutureDateTime, 0);
+            seen[randomFutureDateTime]++;
+            
+            Assert.True(seen[randomFutureDateTime] <= 2);
         }
     }
 

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -171,10 +171,11 @@ public class RandomizationHelperTests
     }
 
     [Theory]
-    [InlineData(1, 1)]
-    [InlineData(3, 1)]
-    public void RandomIntegerGenerationWithInvalidBoundariesShouldFail(int min, int max)
+    [InlineData(1UL, 1UL, true)]
+    [InlineData(1UL, 0UL, true)]
+    [InlineData(1UL, 0UL, false)]
+    public void RandomIntegerGenerationWithInvalidBoundariesShouldFail(ulong min, ulong max, bool upperBoundIsExclusive)
     {
-        Assert.Throws<InvalidOperationException>(() => _ = RandomizationHelper.RandomInteger(min, max));
+        Assert.Throws<InvalidOperationException>(() => _ = RandomizationHelper.RandomUnsignedLongInteger(min, max, upperBoundIsExclusive));
     }
 }

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -22,12 +22,21 @@ public class RandomizationHelperTests
     [Fact]
     public void RandomIntegerShouldNeverExceedBoundaries()
     {
-        for (var i = 1; i <= 1000; i++)
+        const int iterations = 10000;
+        for (var i = 1; i <= iterations; i++)
         {
             var randomInteger = RandomizationHelper.RandomInteger(0, i);
 
             Assert.True(randomInteger >= 0);
             Assert.True(randomInteger < i);
+        }
+
+        for (var i = 1; i <= iterations; i++)
+        {
+            var randomInteger = RandomizationHelper.RandomInteger(0, i, upperBoundIsExclusive: false);
+
+            Assert.True(randomInteger >= 0);
+            Assert.True(randomInteger <= i);
         }
     }
 
@@ -36,10 +45,6 @@ public class RandomizationHelperTests
     [InlineData(3, 1)]
     public void RandomIntegerGenerationWithInvalidBoundariesShouldFail(int min, int max)
     {
-        Assert.Throws<InvalidOperationException>(
-            () =>
-            {
-                _ = RandomizationHelper.RandomInteger(min, max);
-            });
+        Assert.Throws<InvalidOperationException>(() => _ = RandomizationHelper.RandomInteger(min, max));
     }
 }

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 public class RandomizationHelperTests
 {
+    private const int ITERATIONS = 500;
+    
     [Fact]
     public void GetRandomStringShouldValidateLength()
     {
@@ -23,8 +25,7 @@ public class RandomizationHelperTests
     [Fact]
     public void RandomIntegerShouldBeGeneratedCorrectly()
     {
-        const int iterations = 10000;
-        for (var i = 1; i <= iterations; i++)
+        for (var i = 1; i <= ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomInteger(0, i);
 
@@ -32,7 +33,7 @@ public class RandomizationHelperTests
             Assert.True(randomNumber < i);
         }
 
-        for (var i = 1; i <= iterations; i++)
+        for (var i = 1; i <= ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomInteger(0, i, upperBoundIsExclusive: false);
 
@@ -41,7 +42,7 @@ public class RandomizationHelperTests
         }
 
         var seen = new HashSet<int>();
-        for (var i = 0; i < iterations; i++)
+        for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomInteger();
             Assert.DoesNotContain(randomNumber, seen);
@@ -52,8 +53,7 @@ public class RandomizationHelperTests
     [Fact]
     public void RandomUnsignedIntegerShouldBeGeneratedCorrectly()
     {
-        const uint iterations = 10000;
-        for (var i = 1U; i <= iterations; i++)
+        for (var i = 1U; i <= ITERATIONS; i++)
         {
             uint inclusiveLowerBound = 1000U, exclusiveUpperBound = 1000U + i;
             var randomNumber = RandomizationHelper.RandomUnsignedInteger(inclusiveLowerBound, exclusiveUpperBound);
@@ -62,7 +62,7 @@ public class RandomizationHelperTests
             Assert.True(randomNumber < exclusiveUpperBound);
         }
 
-        for (var i = 1U; i <= iterations; i++)
+        for (var i = 1U; i <= ITERATIONS; i++)
         {
             uint inclusiveLowerBound = 1000U, inclusiveUpperBound = 1000U + i;
             var randomNumber = RandomizationHelper.RandomUnsignedInteger(inclusiveLowerBound, inclusiveUpperBound, upperBoundIsExclusive: false);
@@ -72,7 +72,7 @@ public class RandomizationHelperTests
         }
 
         var seen = new HashSet<uint>();
-        for (var i = 0; i < iterations; i++)
+        for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomUnsignedInteger();
             Assert.DoesNotContain(randomNumber, seen);
@@ -83,8 +83,7 @@ public class RandomizationHelperTests
     [Fact]
     public void RandomLongIntegerShouldBeGeneratedCorrectly()
     {
-        const int iterations = 10000;
-        for (var i = 1; i <= iterations; i++)
+        for (var i = 1; i <= ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomLongInteger(0, i);
 
@@ -92,7 +91,7 @@ public class RandomizationHelperTests
             Assert.True(randomNumber < i);
         }
 
-        for (var i = 1; i <= iterations; i++)
+        for (var i = 1; i <= ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomLongInteger(0, i, upperBoundIsExclusive: false);
 
@@ -101,9 +100,71 @@ public class RandomizationHelperTests
         }
 
         var seen = new HashSet<long>();
-        for (var i = 0; i < iterations; i++)
+        for (var i = 0; i < ITERATIONS; i++)
         {
             var randomNumber = RandomizationHelper.RandomLongInteger();
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomUnsignedLongIntegerShouldBeGeneratedCorrectly()
+    {
+        for (var i = 1UL; i <= ITERATIONS; i++)
+        {
+            ulong inclusiveLowerBound = 1000UL, exclusiveUpperBound = 1000U + i;
+            var randomNumber = RandomizationHelper.RandomUnsignedLongInteger(inclusiveLowerBound, exclusiveUpperBound);
+
+            Assert.True(randomNumber >= inclusiveLowerBound);
+            Assert.True(randomNumber < exclusiveUpperBound);
+        }
+
+        for (var i = 1UL; i <= ITERATIONS; i++)
+        {
+            ulong inclusiveLowerBound = 1000UL, inclusiveUpperBound = 1000U + i;
+            var randomNumber = RandomizationHelper.RandomUnsignedLongInteger(inclusiveLowerBound, inclusiveUpperBound, upperBoundIsExclusive: false);
+
+            Assert.True(randomNumber >= inclusiveLowerBound);
+            Assert.True(randomNumber <= inclusiveUpperBound);
+        }
+
+        var seen = new HashSet<ulong>();
+        for (var i = 0; i < ITERATIONS; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomUnsignedLongInteger();
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomDoubleShouldWorkCorrectly()
+    {
+        var seen = new HashSet<double>();
+        for (var i = 0; i < ITERATIONS; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomDouble();
+            
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber < 1);
+
+            Assert.DoesNotContain(randomNumber, seen);
+            seen.Add(randomNumber);
+        }
+    }
+
+    [Fact]
+    public void RandomFloatShouldWorkCorrectly()
+    {
+        var seen = new HashSet<float>();
+        for (var i = 0; i < ITERATIONS; i++)
+        {
+            var randomNumber = RandomizationHelper.RandomFloat();
+            
+            Assert.True(randomNumber >= 0);
+            Assert.True(randomNumber < 1);
+
             Assert.DoesNotContain(randomNumber, seen);
             seen.Add(randomNumber);
         }

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/PrimitiveRandomization/RandomizationHelperTests.cs
@@ -13,26 +13,17 @@ public class RandomizationHelperTests
     public void GetRandomStringShouldValidateLength()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => RandomizationHelper.GetRandomString(-1, "mask"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => RandomizationHelper.GetRandomString(-1, new[] { 'a' }));
     }
 
     [Fact]
     public void GetRandomStringShouldValidateMask()
     {
-        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, null!));
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, (string)null!));
         Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, string.Empty));
-    }
 
-    [Fact]
-    public void GetRandomStringCombinationShouldValidateLength()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => RandomizationHelper.GetRandomStringCombination(-1, new[] { 'a' }));
-    }
-
-    [Fact]
-    public void GetRandomStringCombinationShouldValidateMask()
-    {
-        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomStringCombination(5, null!));
-        Assert.Throws<ArgumentException>(() => RandomizationHelper.GetRandomStringCombination(5, Array.Empty<char>()));
+        Assert.Throws<ArgumentNullException>(() => RandomizationHelper.GetRandomString(5, (char[])null!));
+        Assert.Throws<ArgumentException>(() => RandomizationHelper.GetRandomString(5, Array.Empty<char>()));
     }
 
     [Fact]

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
@@ -13,14 +13,14 @@
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.3.0.71466">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>


### PR DESCRIPTION
## Pull Request Description 

Added methods for generating random values for all aforementioned types.

## Motivation and Context

This PR should resolve a well known non-blocking issue by introducing all required mechanisms to simplify the generation of primitive values.
Moreover, the new methods for generating random numerical values allow to refine the minimum and maximum for the generated values. This change fixes #39.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
