### PR TITLE
Development package updates; Replacing Moq with NSubstitute; Pipeline updates

### DIFF
--- a/.github/workflows/Core validation.yml
+++ b/.github/workflows/Core validation.yml
@@ -25,10 +25,11 @@ jobs:
       with:
         dotnet-version: 7.x
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.11
+        distribution: microsoft
+        java-version: 21
 
     - name: Cache SonarCloud packages
       uses: actions/cache@v1

--- a/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
+++ b/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.21.0.86780">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
@@ -14,7 +14,7 @@
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="9.21.0.86780">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
+++ b/tests/TryAtSoftware.Randomizer.Core.Tests/TryAtSoftware.Randomizer.Core.Tests.csproj
@@ -7,20 +7,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.21.0.86780">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>


### PR DESCRIPTION
## Pull Request Description 

All development packages (analyzers and libraries used in test) are updated to the latest version.
Replaced Moq with NSubstitute in our tests (following the idea approached in other repositories within the TryAtSoftware organization).
Updated the `Core Validation` package so that the LTS version of Java (currently this is 21) is used in automated builds.

## Motivation and Context

We need to maintain the `Randomizer` project even though it is not the most prioritized one.

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
