### PR TITLE
Increased the `TryAtSoftware.Randomizer` package version to v2.0.2

### DIFF
--- a/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
+++ b/src/TryAtSoftware.Randomizer.Core/TryAtSoftware.Randomizer.Core.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 		
         <PackageId>TryAtSoftware.Randomizer</PackageId>
-        <Version>2.0.2-alpha.1</Version>
+        <Version>2.0.2</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/Randomizer</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR will introduce a new patch release for the `TryAtSoftware.Randomizer` package that introduces some new methods for randomizing numerical types or buffers throughout the `RandomizationHelper` class.